### PR TITLE
Fix content size of dls in the modern template when pdf-izing

### DIFF
--- a/templates/modern/css/pdf.css
+++ b/templates/modern/css/pdf.css
@@ -91,6 +91,8 @@ body.pdf {
         margin: .7em 0 0;
         page-break-inside: avoid !important;
         display: block;
+        width:84%;
+        float: left;
         dt {}
         dd {
         }


### PR DESCRIPTION
Found <dls> were drifting over to the left margin when being run through wkhtmltopdf.  This should fix the indentation.
