### PR TITLE
added optional argument to override output filename

### DIFF
--- a/src/Resume/Command/HtmlCommand.php
+++ b/src/Resume/Command/HtmlCommand.php
@@ -43,6 +43,12 @@ class HtmlCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Regenerate the html and include a meta command to refresh the ' .
                 'document every periodically. Measured in seconds.'
+            )
+            ->addOption(
+                'output',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'The optional override of default filename to output to'
             );
     }
 
@@ -50,10 +56,18 @@ class HtmlCommand extends Command
     {
         $this->app    = $this->getApplication();
         $source       = $input->getArgument('source');
+        $sourceName   = pathinfo($source, PATHINFO_FILENAME);
         $destination  = rtrim($input->getArgument('destination'), DIRECTORY_SEPARATOR);
         $template     = $input->getOption('template');
         $refresh      = $input->getOption('refresh');
-        $destFilename = join(DIRECTORY_SEPARATOR, array($destination, pathinfo($source, PATHINFO_FILENAME) . '.html'));
+        $optFilename  = $input->getOption('output');
+        $destFilename = "";
+
+        if ($optFilename) {
+            $destFilename = $destination . DIRECTORY_SEPARATOR . $optFilename . '.html';
+        } else {
+            $destFilename = $destination . DIRECTORY_SEPARATOR . $sourceName . '.html';
+        }
 
         $rendered = $this->generateHtml($source, $template, $refresh);
         file_put_contents($destFilename, $rendered);
@@ -150,6 +164,12 @@ class HtmlCommand extends Command
         ));
 
         return $rendered;
+    }
+
+    protected function determineOutfile($outputFilename)
+    {
+        return join(DIRECTORY_SEPARATOR, array($destination, pathinfo($source, PATHINFO_FILENAME) . '.html'));
+
     }
 }
 

--- a/src/Resume/Command/PdfCommand.php
+++ b/src/Resume/Command/PdfCommand.php
@@ -30,6 +30,12 @@ class PdfCommand extends HtmlCommand
                 't',
                 InputOption::VALUE_REQUIRED,
                 'Which of the templates to use'
+            )
+            ->addOption(
+                'output',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'The optional override of default filename to output to'
             );
     }
 
@@ -37,11 +43,19 @@ class PdfCommand extends HtmlCommand
     {
         $this->app    = $this->getApplication();
         $source       = $input->getArgument('source');
+        $sourceName   = pathinfo($source, PATHINFO_FILENAME);
         $destination  = rtrim($input->getArgument('destination'), DIRECTORY_SEPARATOR);
         $template     = $input->getOption('template');
         $pdfSource    = join(DIRECTORY_SEPARATOR, array($destination, '.tmp_pdf_source.html'));
+        $optFilename  = $input->getOption('output');
+
         $destFilename = join(DIRECTORY_SEPARATOR, array($destination, pathinfo($source, PATHINFO_FILENAME) . '.pdf'));
 
+        if ($optFilename) {
+            $destFilename = $destination . DIRECTORY_SEPARATOR . $optFilename . '.pdf';
+        } else {
+            $destFilename = $destination . DIRECTORY_SEPARATOR . $sourceName . '.pdf';
+        }
         // Make sure we've got out converter available
         exec('wkhtmltopdf -V', $results, $returnVal);
         if ($returnVal) {


### PR DESCRIPTION
the `-o` or `--output` argument flag will let you override the output filename, while preserving default behavior. Should close #18 