### PR TITLE
Update modern template

### DIFF
--- a/templates/modern/css/pdf.css
+++ b/templates/modern/css/pdf.css
@@ -44,7 +44,7 @@ body.pdf {
     }
     h3+p {
         float: left;
-        width: 84%;
+        width: 78%;
     }
 
     blockquote {
@@ -54,7 +54,7 @@ body.pdf {
     }
 
     ul li {
-        width: 28%;
+        width: 26%;
         float: left;
     }
     ul dl {
@@ -72,7 +72,7 @@ body.pdf {
 
     ol {
         float: left;
-        width: 84%;
+        width: 79%;
         margin: .7em 0 0;
     }
 
@@ -91,7 +91,7 @@ body.pdf {
         margin: .7em 0 0;
         page-break-inside: avoid !important;
         display: block;
-        width:84%;
+        width:79%;
         float: left;
         dt {}
         dd {

--- a/templates/modern/css/resume.css
+++ b/templates/modern/css/resume.css
@@ -82,7 +82,7 @@ h2 {
 }
 
 h3 {
-    margin: 0;
+    margin: 0px 20px;
     padding: 0 0 .5em;
     font-size: 150%;
     font-style: italic;
@@ -146,7 +146,7 @@ ol li:nth-child(1) {
 
 dl {
     display: inline-block;
-    width: 75%;
+    width: 78%;
     margin: 0;
     padding: 0;
     dt {

--- a/templates/modern/css/screen.css
+++ b/templates/modern/css/screen.css
@@ -91,11 +91,11 @@
     
     h3+p {
         float: left;
-        width: 84%;
+        width: 78%;
     }
     
     ul li {
-        width: 28%;
+        width: 25%;
         float: left;
     }
     ul dl {
@@ -111,7 +111,7 @@
 
     ol {
         float: left;
-        width: 84%;
+        width: 79%;
         margin: .6em 0 0;
     }
 


### PR DESCRIPTION
The second-level headers in the `modern` template don't have much of a margin, and thus can end up uncomfortably close to the content. Example:

![bad-margins](https://cloud.githubusercontent.com/assets/676533/6654234/d8d7468a-ca73-11e4-8cff-1102ab042696.png)

This PR fixes that, hopefully while leaving everything else intact.

I checked the results with both the included `sample.md` and my resume, and it seems to look okay.

I'm not sure if any of the other templates have this problem, since `modern` is the only one I use. If they do, let me know if I should apply this fix to them and resubmit.
