### PR TITLE
Fix list overflow for modern template

### DIFF
--- a/templates/modern/css/pdf.css
+++ b/templates/modern/css/pdf.css
@@ -54,7 +54,7 @@ body.pdf {
     }
 
     ul li {
-        width: 26%;
+        width: 33%;
         float: left;
     }
     ul dl {

--- a/templates/modern/css/resume.css
+++ b/templates/modern/css/resume.css
@@ -102,6 +102,7 @@ ul {
     margin: 0;
     padding: 0;
     list-style: none;
+    display: table;
 }
 ul li {
     margin: 0;

--- a/templates/modern/css/screen.css
+++ b/templates/modern/css/screen.css
@@ -95,7 +95,7 @@
     }
     
     ul li {
-        width: 25%;
+        width: 33%;
         float: left;
     }
     ul dl {


### PR DESCRIPTION
This fixes the tendency of large lists to flow past the section header and cause the columns of the list to not be aligned correctly.
This also fixes an issue with the spacing between the end of said lists and `<hr>`s.

Example of both issues:
![list-overflow](https://cloud.githubusercontent.com/assets/676533/6680462/db034e66-cc14-11e4-8db2-aa288527338c.png)
