### PR TITLE
Decrease padding between items in Skills section

### DIFF
--- a/templates/modern/css/pdf.css
+++ b/templates/modern/css/pdf.css
@@ -66,7 +66,7 @@ body.pdf {
             margin: 0 0 .75em;
         }
         dd {
-            padding: 0 4em 0 0;
+            padding: 0 2em 0 0;
         }
     }
 

--- a/templates/modern/css/screen.css
+++ b/templates/modern/css/screen.css
@@ -105,7 +105,7 @@
             margin-bottom: .75em;
         }
         dd {
-            padding: 0 4em 0 0;
+            padding: 0 2em 0 0;
         }
     }
 


### PR DESCRIPTION
This wastes less empty space, and prevents lines from wrapping too early.