### PR TITLE
Fix list overflow for swissen template

### DIFF
--- a/templates/swissen/css/pdf.css
+++ b/templates/swissen/css/pdf.css
@@ -52,7 +52,7 @@ body.pdf {
     }
 
     ul li {
-        width: 28%;
+        width: 33.33%;
         float: left;
     }
     ul dl {

--- a/templates/swissen/css/resume.css
+++ b/templates/swissen/css/resume.css
@@ -109,6 +109,7 @@ ul {
     margin: 0;
     padding: 0;
     list-style: none;
+    display: table;
 }
 ul li {
     margin: 0;

--- a/templates/swissen/css/screen.css
+++ b/templates/swissen/css/screen.css
@@ -91,7 +91,7 @@
     }
     
     ul li {
-        width: 28%;
+        width: 33.33%;
         float: left;
     }
     ul dl {


### PR DESCRIPTION
Based on there4/markdown-resume@ca2e1db; fixes the issue where list items (such as those in the 'skills' section of sample.md) don't align correctly if there's enough of them to wrap past the right margin. Also fixes the width of those list items (there was wasted space on the right before).