### PR TITLE
Widen section labels on swissen template

### DIFF
--- a/templates/swissen/css/pdf.css
+++ b/templates/swissen/css/pdf.css
@@ -37,12 +37,12 @@ body.pdf {
     }
     h3 {
         float: left;
-        width: 16%;
+        width: 20%;
         font-style: normal;
     }
     h3+p {
         float: left;
-        width: 84%;
+        width: 80%;
     }
 
     blockquote {
@@ -70,7 +70,7 @@ body.pdf {
 
     ol {
         float: left;
-        width: 84%;
+        width: 80%;
         margin: .7em 0 0;
     }
 

--- a/templates/swissen/css/resume.css
+++ b/templates/swissen/css/resume.css
@@ -133,7 +133,7 @@ ul dl {
 ol {
     margin: 0;
     padding: 0 0 .75em;
-    width: 84%;
+    width: 80%;
     display: inline-block;
 }
 

--- a/templates/swissen/css/screen.css
+++ b/templates/swissen/css/screen.css
@@ -82,12 +82,12 @@
     
     h3 {
         float: left;
-        width: 16%;
+        width: 20%;
     }
     
     h3+p {
         float: left;
-        width: 84%;
+        width: 80%;
     }
     
     ul li {
@@ -107,7 +107,7 @@
 
     ol {
         float: left;
-        width: 84%;
+        width: 80%;
         margin: .6em 0 0;
     }
 


### PR DESCRIPTION
I noticed that on the swissen template, the word "experience" was a bit too long to use as a section label. Given that this is a pretty short word, and also a very common section label for résumés, I widened the section labels from 16% of the total width to 20% (and reduced the width of the main text area to match) for both html and pdf renderings.