### PR TITLE
Force wkhtmltopdf to render with dpi of 300

### DIFF
--- a/src/Resume/Command/PdfCommand.php
+++ b/src/Resume/Command/PdfCommand.php
@@ -83,7 +83,7 @@ class PdfCommand extends HtmlCommand
         file_put_contents($pdfSource, $rendered);
 
         // Process the document with wkhtmltopdf
-        exec('wkhtmltopdf ' . $pdfSource .' ' . $destFilename);
+        exec('wkhtmltopdf  --dpi 300' . $pdfSource .' ' . $destFilename);
 
         // Unlink the temporary file
         unlink($pdfSource);


### PR DESCRIPTION
## Problem
The rendered output with new versions of wkhtmltopdf is incorrect.

## Solution
We now force `wkhtmltopdf` to render with a DPI of 300 as recommended by https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3266#issuecomment-335547684

Closes #60 