### PR TITLE
fixes the ternary operator to set the correct autoloadPath

### DIFF
--- a/bin/md2resume
+++ b/bin/md2resume
@@ -7,12 +7,10 @@ $cwd = getcwd();
 $templatePath = $baseDir . '/templates';
 $consoleTemplatePath = $baseDir . '/src/Resume/Templates';
 
-// When md2resume is installed with composer, it resides in the a
-// 'markdown-resume' subdirectory of the 'vendor' directory, so we need to
-// walk up a few folders to find 'autoload.php'.
-$autoloadPath = basename($baseDir) === 'markdown-resume'
-              ? realpath($baseDir . '/../../autoload.php')
-              : $baseDir . '/vendor/autoload.php';
+// When md2resume is used as a dependency with composer, it resides in the
+// 'vendor/markdown-resume' directory. This means that the 'autoload.php' is
+// actually much higher in the directory tree than is normally expected.
+$autoloadPath = (strpos($baseDir, 'vendor')) ? realpath($baseDir . '/../../autoload.php') : $baseDir . '/vendor/autoload.php';
 
 // If the dependencies aren't installed, we have to bail and offer some help.
 if (!file_exists($autoloadPath)) {


### PR DESCRIPTION
resolves #77.

The issue with the fix proposed in #66 is that the markdown-resume directory will always be within the path even when it's added as a package in its own composer file. As such, it means that the first argument in the ternary operator will always return. 

If you want to test this:

```bash
echo "Testing as a normal install"
cd $(mktemp -d)
git clone https://github.com/johnpneumann/markdown-resume.git normal
cd normal
git checkout 77_fix_autoload_path
composer install
bin/md2resume
cd ..
echo "Testing as a dependency"
mkdir as-dependency
cd as-dependency
cat > composer.json <<EOF
{
    "name": "md2resume-test",
    "minimum-stability": "dev",
    "repositories": [
        {
            "type": "path",
            "url": "../normal"
        }
    ],
    "require": {
        "php": ">=7.1",
        "there4/markdown-resume": "*"
    }
}
EOF
composer install
vendor/bin/md2resume
f=$(egrep '^\$autoloadPath' vendor/bin/md2resume)
g=$(egrep '^\$autoloadPath' ../normal/bin/md2resume)
[[ "${f}" == "${g}" ]] && echo "autoloadPaths match"
```

Hopefully that's clear as mud. I haven't written PHP in a decade and have no experience with composer outside of today, so if there's a better way for this, feel free to correct.