### PR TITLE
docker: fix "md2resume pdf" command on docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Wrap pdf creation in a xvfb-run to enable headless pdf creation in the container
-RUN printf '#!/bin/bash\nxvfb-run md2resume pdf "$@"' >> /usr/bin/md2pdf \
-    && chmod +x /usr/bin/md2pdf
+RUN echo "#!/bin/bash\nxvfb-run $(which wkhtmltopdf) \"\$@\"" >> /usr/local/bin/wkhtmltopdf \
+    && chmod +x /usr/local/bin/wkhtmltopdf
 
 # Enables continously calling a command and piping the output to STDOUT, viewable via docker logs
 RUN printf '#!/bin/bash\nwhile sleep 1; do\n    "$@"\ndone' >> /usr/bin/watch-docker \


### PR DESCRIPTION
The `md2pdf` bash script created during the Docker image build was
invalid. For some reason, it was scrapping out the line break:

```
root@92820d4e9bc1:/resume# cat /usr/bin/md2pdf
```

As a result `md2resume` was failing silently. Also, it was not possible
to run wkhtmltopdf standalone headlessly inside the container. These
changes allow wkhtmltopdf to be run headlessly and fix the issue with
`md2resume pdf`.