### PR TITLE
wkhtmltopdf from vendor rather than debian upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,19 @@ RUN apt-get update \
 	&& apt-get install -qqy --no-install-recommends\
         # This is for enabling the program to be run with watch
         procps \
-        wkhtmltopdf \
         # Required to run PDF generation
         xvfb \
         xauth \
+        wget apt-utils libjpeg62-turbo libxrender1 xfonts-75dpi xfonts-base fontconfig \
 	&& rm -rf /var/lib/apt/lists/*
 
+RUN cd /root && \
+    wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb && \
+    dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb
+
 # Wrap pdf creation in a xvfb-run to enable headless pdf creation in the container
-RUN echo "#!/bin/bash\nxvfb-run $(which wkhtmltopdf) \"\$@\"" >> /usr/local/bin/wkhtmltopdf \
-    && chmod +x /usr/local/bin/wkhtmltopdf
+# RUN echo "#!/bin/bash\nxvfb-run $(which wkhtmltopdf) \"\$@\"" >> /usr/local/bin/wkhtmltopdf \
+#     && chmod +x /usr/local/bin/wkhtmltopdf
 
 # Enables continously calling a command and piping the output to STDOUT, viewable via docker logs
 RUN printf '#!/bin/bash\nwhile sleep 1; do\n    "$@"\ndone' >> /usr/bin/watch-docker \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
         # This is for enabling the program to be run with watch
         procps \
         # Required to run PDF generation
-        wget apt-utils libjpeg62-turbo libxrender1 xfonts-75dpi xfonts-base fontconfig \
+        wget apt-utils libjpeg62-turbo libxrender1 xfonts-75dpi xfonts-base fontconfig libxext6 \
     && apt-get autoremove \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,17 @@ WORKDIR /resume
 CMD ["/bin/bash"]
 
 RUN apt-get update \
-	&& apt-get install -qqy --no-install-recommends\
+	&& apt-get install -qqy --no-install-recommends \
         # This is for enabling the program to be run with watch
         procps \
         # Required to run PDF generation
         wget apt-utils libjpeg62-turbo libxrender1 xfonts-75dpi xfonts-base fontconfig libxext6 \
-    && apt-get autoremove \
+        && apt-get autoremove \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN cd /root && \
-    wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb && \
-    dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb
+RUN cd /root \
+    && wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb --no-verbose \
+    && dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb
 
 # Enables continously calling a command and piping the output to STDOUT, viewable via docker logs
 RUN printf '#!/bin/bash\nwhile sleep 1; do\n    "$@"\ndone' >> /usr/bin/watch-docker \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,13 @@ RUN apt-get update \
         # This is for enabling the program to be run with watch
         procps \
         # Required to run PDF generation
-        xvfb \
-        xauth \
         wget apt-utils libjpeg62-turbo libxrender1 xfonts-75dpi xfonts-base fontconfig \
+    && apt-get autoremove \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN cd /root && \
     wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb && \
     dpkg -i wkhtmltox_0.12.5-1.stretch_amd64.deb
-
-# Wrap pdf creation in a xvfb-run to enable headless pdf creation in the container
-# RUN echo "#!/bin/bash\nxvfb-run $(which wkhtmltopdf) \"\$@\"" >> /usr/local/bin/wkhtmltopdf \
-#     && chmod +x /usr/local/bin/wkhtmltopdf
 
 # Enables continously calling a command and piping the output to STDOUT, viewable via docker logs
 RUN printf '#!/bin/bash\nwhile sleep 1; do\n    "$@"\ndone' >> /usr/bin/watch-docker \


### PR DESCRIPTION
`wkhtmltopdf` from Debian upstream is gimped so cannot include graphics. Instead, use `wkhtmltopdf` direct from the vendor to enable full functionality.