### PR TITLE
pass command line args to wkhtmltopdf to enable better formatting

### DIFF
--- a/src/Resume/Command/PdfCommand.php
+++ b/src/Resume/Command/PdfCommand.php
@@ -104,8 +104,8 @@ class PdfCommand extends HtmlCommand
         // Save to a temp destination for the pdf renderer to use
         file_put_contents($pdfSource, $rendered);
 
+        // command that will be invoked to convert html to pdf
         $cmd = "wkhtmltopdf $pdfargs $pdfSource $destFilename";
-        // $output->writeln($cmd);
 
         // Process the document with wkhtmltopdf
         if(!$htmlonly)


### PR DESCRIPTION
Added 3 options to `PdfCommand`:

- The first 2 options are variants of keeping the interim HTML that gets passed to `wkhtmltopdf` instead of removing it. This is useful for debugging (e.g. CSS issues that aren't transparent when only viewing the final PDF).  
- The third option is to pass arguments through to `wkhtmltopdf` which enables better control of PDF generation (e.g. margins, media type).