### PR TITLE
Set utf8 encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN composer install --no-dev --optimize-autoloader --no-progress --no-suggest
 # Build the actual image
 FROM php
 
+ENV LC_ALL C.UTF-8
 WORKDIR /resume
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
Now other characters won't display as `?`

Although generate pdf need more modification such as installing fonts.